### PR TITLE
Ensure struct was compiled

### DIFF
--- a/lib/maptu.ex
+++ b/lib/maptu.ex
@@ -284,7 +284,7 @@ defmodule Maptu do
   end
 
   defp ensure_struct(mod) when is_atom(mod) do
-    if function_exported?(mod, :__struct__, 0) do
+    if Code.ensure_compiled?(mod) && function_exported?(mod, :__struct__, 0) do
       :ok
     else
       {:error, {:non_struct, mod}}


### PR DESCRIPTION
I am facing the issue that I get a :non_struct error, when trying to convert my map to a struct. It seems like this happens when the Module was not loaded before.

```
iex(1)> Maptu.struct(MyStruct, %{}) # does not work
{:error, {:non_struct, MyStruct}}

iex(2)> %MyStruct{}
%MyStruct{name: "", url: ""}

iex(3)> Maptu.struct(MyStruct, %{}) # now it works
{:ok, %MyStruct{name: "", url: ""}}
```

So I added a `Code.ensure_compiled?(mod)` check to ensure the module is loaded.

My System:
Erlang/OTP 19
Elixir (1.4.2)