### PR TITLE
Propose a macro to work with structs with enforced keys

### DIFF
--- a/test/maptu_test.exs
+++ b/test/maptu_test.exs
@@ -3,6 +3,22 @@ defmodule MaptuTest do
 
   doctest Maptu
 
+  defmodule Dummy do
+    import Maptu
+
+    @enforce_keys [:foo, :bar]
+    @keys @enforce_keys ++ [:qwe]
+
+    defstruct @keys
+
+    defmaptu(:new, @keys)
+  end
+
+  test "defmaptu/2" do
+    assert Dummy.new(%{"foo" => 1}) == :error
+    assert Dummy.new(%{"foo" => 1, "bar" => 1, "qwe" => 1}) == :ok
+  end
+
   test "struct/1 and strict_struct/1: no __struct__ key in the given map" do
     assert Maptu.struct(%{"foo" => "bar"}) == {:error, :missing_struct_key}
     assert Maptu.strict_struct(%{"foo" => "bar"}) == {:error, :missing_struct_key}


### PR DESCRIPTION
Hello, I'd like to propose a macro to work with structs having enforced keys. In general it could work like this:

```ex
defstruct Post do
  import Maptu, only: [defmaptu: 2]

  @enforce_keys [:title, :content]
  @struct_keys @enforce_keys ++ [:description]
  defstruct @struct_keys

  defmaptu :new, @struct_keys
end
```

So this macro would generate a `new` function in the module, which transforms string-key map into its struct, with enforced keys taken into account.

The code in the PR is given as the proof of concept. I would be glad to hear any suggestions or recommendations.